### PR TITLE
feat: host as Azure Static Web App with Functions API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# Create React App treats lint warnings as errors when CI=true (which CI builders,
+# including Azure Static Web Apps / Oryx, set automatically). This repo has several
+# pre-existing benign warnings (a11y alt-text, unused vars, hook deps), so disable that
+# escalation to keep production builds from failing on warnings.
+CI=false

--- a/.github/workflows/azure-static-web-apps-black-sea-025cd1d0f.yml
+++ b/.github/workflows/azure-static-web-apps-black-sea-025cd1d0f.yml
@@ -29,7 +29,7 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
+          api_location: "api" # Azure Functions API (users/favorites/reviews)
           output_location: "build" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,46 @@ After all installation steps are complete, navigate to the root directory of the
 
 Happy Viewing
 
+## Deploying to Azure (Static Web App)
+
+Remote-Watch can be hosted as an **Azure Static Web App**: the React UI is served as static
+files, and the users/favorites/reviews API ships as a bundled **Azure Functions** app
+(`api/`) backed by **Azure Table Storage** — this replaces the dev-only `json-server`. The
+GitHub Actions workflow in `.github/workflows/` already builds and deploys both.
+
+### 1. Provision Azure resources
+
+1. **Storage account** (for Table Storage) — create one, then copy its **connection
+   string** (Access keys blade).
+2. **Static Web App** — create one pointed at this GitHub repo, branch `main`, with build
+   settings: app location `/`, api location `api`, output location `build`. Azure adds the
+   deployment-token secret to the repo automatically.
+3. In the Static Web App → **Configuration** (application settings), add
+   `TABLES_CONNECTION_STRING` = the storage connection string from step 1.
+4. **Seed the admin user** once: from `api/`,
+   `TABLES_CONNECTION_STRING="<conn string>" npm run seed`.
+
+### 2. Make Plex reachable (required, or no movies will load)
+
+The browser streams **directly** from your Plex server, so a deployed HTTPS app needs:
+
+- **Plex Remote Access enabled** so the server is reachable from the internet
+  (Plex → Settings → Remote Access).
+- An **HTTPS** Plex URL. A plain `http://<ip>:<port>` URL is blocked by the browser as
+  *mixed content* on an HTTPS site. Use your server's secure `*.plex.direct` address (Plex
+  issues these certs) — e.g. `https://<dash-encoded-ip>.<hash>.plex.direct:32400`.
+- Plex **CORS** permitting your Static Web App origin.
+
+Put the HTTPS Plex URL, token, and library ID in `Settings.js` (it is bundled into the
+build). **Note:** the X-Plex-Token ends up in the public client bundle, so only deploy a
+collection/token you're comfortable exposing.
+
+### 3. Deploy
+
+Push to `main`. The workflow builds the app + API and deploys. `dbURL` automatically points
+at `/api` in the production build (see `Settings-template.js`), so no code change is needed
+between local and cloud.
+
 ## Help
 
 If you need assistance with any of the above, reach me on Github or Twitter, @ActuallyAJL and I will send resources that will help.

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,8 @@
+# Azure Functions
+bin
+obj
+node_modules
+local.settings.json
+
+# json-server data (dev-only); real data lives in Azure Table Storage
+database.json

--- a/api/host.json
+++ b/api/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/api/local.settings.json.example
+++ b/api/local.settings.json.example
@@ -1,0 +1,12 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "TABLES_CONNECTION_STRING": "UseDevelopmentStorage=true"
+  },
+  "Host": {
+    "CORS": "http://localhost:3000",
+    "CORSCredentials": false
+  }
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,378 @@
+{
+  "name": "remote-watch-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "remote-watch-api",
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/data-tables": "^13.2.2",
+        "@azure/functions": "^4.5.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/data-tables": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.3.2.tgz",
+      "integrity": "sha512-PZ8e4SnCpTQEbQ1P+CK6NR7Vhb86Jw1S1qJi2IcF1ij4qiPX2b4vIemwNPkYg/gZGMqKbxkPvGRpRmEbBYdXuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.4",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.0.tgz",
+      "integrity": "sha512-cwLld7tRi1VLYNdm1evgS9n8ABP/e+0uLjRO++OjM/kigERG80OfFRRMbag/vpXUzCtda83lDiuCvcwPlxgwZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/functions-extensions-base": "0.3.0",
+        "cookie": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@azure/functions-extensions-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+      "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "remote-watch-api",
+  "version": "1.0.0",
+  "description": "Azure Functions API for Remote-Watch (users, favorites, reviews) backed by Azure Table Storage. Replaces the dev-only json-server.",
+  "private": true,
+  "main": "src/functions/*.js",
+  "scripts": {
+    "start": "func start",
+    "seed": "node seed.js"
+  },
+  "dependencies": {
+    "@azure/data-tables": "^13.2.2",
+    "@azure/functions": "^4.5.0"
+  }
+}

--- a/api/seed.js
+++ b/api/seed.js
@@ -1,0 +1,42 @@
+// One-off seed: creates the "users" table and an Administrator user (id 1),
+// matching the original database-template.json. Safe to re-run (skips if present).
+//
+// Usage:
+//   TABLES_CONNECTION_STRING="<storage connection string>" node seed.js
+// For the local Azurite emulator you can omit it (defaults to UseDevelopmentStorage=true).
+
+const { TableClient } = require("@azure/data-tables");
+
+const CONN =
+  process.env.TABLES_CONNECTION_STRING ||
+  process.env.AzureWebJobsStorage ||
+  "UseDevelopmentStorage=true";
+
+const ADMIN = {
+  partitionKey: "user",
+  rowKey: "1",
+  name: "Administrator",
+  email: "admin@rm.com",
+  isAdmin: true,
+};
+
+(async () => {
+  const client = TableClient.fromConnectionString(CONN, "users", {
+    allowInsecureConnection: true,
+  });
+  await client.createTable().catch((err) => {
+    if (err?.statusCode !== 409) throw err;
+  });
+
+  try {
+    await client.getEntity(ADMIN.partitionKey, ADMIN.rowKey);
+    console.log("Admin user already exists — nothing to do.");
+  } catch (err) {
+    if (err?.statusCode !== 404) throw err;
+    await client.createEntity(ADMIN);
+    console.log("Seeded Administrator user (id 1, email admin@rm.com).");
+  }
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/api/src/functions/favorites.js
+++ b/api/src/functions/favorites.js
@@ -1,0 +1,57 @@
+const { app } = require("@azure/functions");
+const {
+  getClient,
+  fromEntity,
+  toEntity,
+  listPartition,
+  newId,
+  json,
+} = require("../shared/tables");
+
+const TABLE = "favorites";
+const PARTITION = "favorite";
+
+// Mirrors the json-server `/favorites` endpoints the client uses:
+//   GET    /api/favorites?movieId=<id>   (MovieDetails: is this movie favorited)
+//   GET    /api/favorites?userId=<id>    (parity)
+//   POST   /api/favorites                (add favorite)
+//   DELETE /api/favorites/{id}           (remove favorite)
+app.http("favorites", {
+  route: "favorites/{id?}",
+  methods: ["GET", "POST", "DELETE"],
+  authLevel: "anonymous",
+  handler: async (request) => {
+    const client = await getClient(TABLE);
+    const { id } = request.params;
+
+    if (request.method === "GET") {
+      let favorites = await listPartition(TABLE, PARTITION);
+      const movieId = request.query.get("movieId");
+      const userId = request.query.get("userId");
+      // Loose string compare mirrors json-server (?movieId=123 matches stored number 123).
+      if (movieId !== null) {
+        favorites = favorites.filter((f) => String(f.movieId) === movieId);
+      }
+      if (userId !== null) {
+        favorites = favorites.filter((f) => String(f.userId) === userId);
+      }
+      return json(favorites);
+    }
+
+    if (request.method === "POST") {
+      const body = await request.json();
+      const entity = toEntity(PARTITION, newId(), body);
+      await client.createEntity(entity);
+      return json(fromEntity(entity), 201);
+    }
+
+    // DELETE /api/favorites/{id}
+    if (!id) return json({ error: "id is required" }, 400);
+    try {
+      await client.deleteEntity(PARTITION, id);
+    } catch (err) {
+      if (err?.statusCode !== 404) throw err;
+    }
+    return json({});
+  },
+});

--- a/api/src/functions/reviews.js
+++ b/api/src/functions/reviews.js
@@ -1,0 +1,94 @@
+const { app } = require("@azure/functions");
+const {
+  getClient,
+  fromEntity,
+  toEntity,
+  listPartition,
+  newId,
+  json,
+} = require("../shared/tables");
+
+const TABLE = "reviews";
+const PARTITION = "review";
+const USERS_TABLE = "users";
+const USERS_PARTITION = "user";
+
+// Attach the related user object to each review (replicates json-server's `_expand=user`,
+// which ReviewCard relies on via `thisReview.user?.name`).
+async function expandUsers(reviews) {
+  const users = await listPartition(USERS_TABLE, USERS_PARTITION);
+  const byId = new Map(users.map((u) => [String(u.id), u]));
+  return reviews.map((r) => ({ ...r, user: byId.get(String(r.userId)) || null }));
+}
+
+// Mirrors the json-server `/reviews` endpoints the client uses:
+//   GET    /api/reviews?movieId=<id>&_expand=user   (ReviewList)
+//   GET    /api/reviews?userId=<id>                 (parity)
+//   GET    /api/reviews/{id}                        (parity)
+//   POST   /api/reviews                             (add review)
+//   PATCH  /api/reviews/{id}                        (edit review)
+//   DELETE /api/reviews/{id}                        (delete review)
+app.http("reviews", {
+  route: "reviews/{id?}",
+  methods: ["GET", "POST", "PATCH", "DELETE"],
+  authLevel: "anonymous",
+  handler: async (request) => {
+    const client = await getClient(TABLE);
+    const { id } = request.params;
+
+    if (request.method === "GET") {
+      if (id) {
+        try {
+          const entity = await client.getEntity(PARTITION, id);
+          let review = fromEntity(entity);
+          if (request.query.get("_expand") === "user") {
+            [review] = await expandUsers([review]);
+          }
+          return json(review);
+        } catch (err) {
+          if (err?.statusCode === 404) return json({}, 404);
+          throw err;
+        }
+      }
+      let reviews = await listPartition(TABLE, PARTITION);
+      const movieId = request.query.get("movieId");
+      const userId = request.query.get("userId");
+      if (movieId !== null) {
+        reviews = reviews.filter((r) => String(r.movieId) === movieId);
+      }
+      if (userId !== null) {
+        reviews = reviews.filter((r) => String(r.userId) === userId);
+      }
+      if (request.query.get("_expand") === "user") {
+        reviews = await expandUsers(reviews);
+      }
+      return json(reviews);
+    }
+
+    if (request.method === "POST") {
+      const body = await request.json();
+      const entity = toEntity(PARTITION, newId(), body);
+      await client.createEntity(entity);
+      return json(fromEntity(entity), 201);
+    }
+
+    if (request.method === "PATCH") {
+      if (!id) return json({ error: "id is required" }, 400);
+      const body = await request.json();
+      // toEntity drops the `id` and the expanded `user` object before writing.
+      const entity = toEntity(PARTITION, id, body);
+      await client.updateEntity(entity, "Merge");
+      const updated = await client.getEntity(PARTITION, id);
+      return json(fromEntity(updated));
+    }
+
+    // DELETE /api/reviews/{id}
+    if (!id) return json({ error: "id is required" }, 400);
+    try {
+      await client.deleteEntity(PARTITION, id);
+    } catch (err) {
+      if (err?.statusCode !== 404) throw err;
+    }
+    return json({});
+  },
+});

--- a/api/src/functions/users.js
+++ b/api/src/functions/users.js
@@ -1,0 +1,50 @@
+const { app } = require("@azure/functions");
+const {
+  getClient,
+  fromEntity,
+  toEntity,
+  listPartition,
+  newId,
+  json,
+} = require("../shared/tables");
+
+const TABLE = "users";
+const PARTITION = "user";
+
+// Mirrors the json-server `/users` endpoints the client uses:
+//   GET  /api/users?email=<email>   (login + register existence check)
+//   POST /api/users                 (register)
+//   GET  /api/users/{id}            (convenience / parity)
+app.http("users", {
+  route: "users/{id?}",
+  methods: ["GET", "POST"],
+  authLevel: "anonymous",
+  handler: async (request) => {
+    const client = await getClient(TABLE);
+    const { id } = request.params;
+
+    if (request.method === "GET") {
+      if (id) {
+        try {
+          const entity = await client.getEntity(PARTITION, id);
+          return json(fromEntity(entity));
+        } catch (err) {
+          if (err?.statusCode === 404) return json({}, 404);
+          throw err;
+        }
+      }
+      let users = await listPartition(TABLE, PARTITION);
+      const email = request.query.get("email");
+      if (email !== null) {
+        users = users.filter((u) => String(u.email) === email);
+      }
+      return json(users);
+    }
+
+    // POST — create a user
+    const body = await request.json();
+    const entity = toEntity(PARTITION, newId(), body);
+    await client.createEntity(entity);
+    return json(fromEntity(entity), 201);
+  },
+});

--- a/api/src/shared/tables.js
+++ b/api/src/shared/tables.js
@@ -1,0 +1,111 @@
+// Shared Azure Table Storage helpers for the Remote-Watch API.
+//
+// Design notes:
+// - One table per resource (users / favorites / reviews), single partition each.
+// - IDs are numeric (Date.now()) to preserve the client's strict-equality checks
+//   (e.g. `thisFav.userId === currentUser`, where currentUser is a parseInt'd number).
+//   RowKey must be a string, so we store String(id) and surface `id` as a Number.
+// - Data volumes are tiny (a personal app), so we list a partition and filter in JS
+//   rather than building OData filters — this faithfully mimics json-server's loose
+//   query-param matching (e.g. `?movieId=123` matching a stored number 123).
+
+const { TableClient } = require("@azure/data-tables");
+
+const CONN =
+  process.env.TABLES_CONNECTION_STRING || process.env.AzureWebJobsStorage;
+
+// Table Storage reserved/system property names we never persist from a request body.
+const SYSTEM_PROPS = new Set([
+  "partitionKey",
+  "rowKey",
+  "etag",
+  "timestamp",
+  "PartitionKey",
+  "RowKey",
+  "Timestamp",
+  "ETag",
+]);
+
+const clients = {};
+
+async function getClient(table) {
+  if (!CONN) {
+    throw new Error(
+      "No storage connection string. Set TABLES_CONNECTION_STRING (or AzureWebJobsStorage) " +
+        "in the Function App settings (or local.settings.json for local dev)."
+    );
+  }
+  if (!clients[table]) {
+    const client = TableClient.fromConnectionString(CONN, table, {
+      // Required for the local Azurite emulator (http); harmless against real storage (https).
+      allowInsecureConnection: true,
+    });
+    // Create-if-not-exists; ignore the 409 when it already exists.
+    await client.createTable().catch((err) => {
+      if (err?.statusCode !== 409) throw err;
+    });
+    clients[table] = client;
+  }
+  return clients[table];
+}
+
+// Strip Table system columns and surface a numeric `id` (mirrors json-server's shape).
+function fromEntity(entity) {
+  const out = {};
+  for (const [k, v] of Object.entries(entity)) {
+    if (SYSTEM_PROPS.has(k)) continue;
+    out[k] = v;
+  }
+  out.id = Number(entity.rowKey);
+  return out;
+}
+
+// Build a Table entity from a request body. Drops `id`, system props, nulls, and any
+// nested objects/arrays (Table columns must be primitives — this also discards the
+// `user` object that comes back from an `_expand=user` read before a PATCH writes it).
+function toEntity(partitionKey, id, body) {
+  const entity = { partitionKey, rowKey: String(id) };
+  for (const [k, v] of Object.entries(body || {})) {
+    if (k === "id" || SYSTEM_PROPS.has(k)) continue;
+    if (v === null || typeof v === "object") continue;
+    entity[k] = v;
+  }
+  return entity;
+}
+
+async function listPartition(table, partitionKey) {
+  const client = await getClient(table);
+  const items = [];
+  const entities = client.listEntities({
+    queryOptions: { filter: `PartitionKey eq '${partitionKey}'` },
+  });
+  for await (const e of entities) items.push(fromEntity(e));
+  return items;
+}
+
+// Monotonic-ish numeric id. Date.now() is unique enough for a single-user personal app;
+// the small extra counter guards against collisions within the same millisecond.
+let lastId = 0;
+function newId() {
+  let id = Date.now();
+  if (id <= lastId) id = lastId + 1;
+  lastId = id;
+  return id;
+}
+
+function json(body, status = 200) {
+  return {
+    status,
+    headers: { "Content-Type": "application/json" },
+    jsonBody: body,
+  };
+}
+
+module.exports = {
+  getClient,
+  fromEntity,
+  toEntity,
+  listPartition,
+  newId,
+  json,
+};

--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -1,0 +1,15 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/api/*", "/images/*", "/static/*", "*.{css,js,png,gif,ico,json,svg,webp,txt}"]
+  },
+  "routes": [
+    {
+      "route": "/api/*",
+      "allowedRoles": ["anonymous"]
+    }
+  ],
+  "platform": {
+    "apiRuntime": "node:18"
+  }
+}

--- a/src/components/Settings-template.js
+++ b/src/components/Settings-template.js
@@ -10,8 +10,13 @@ const localPlex = "http://localhost:32400";
 //the url and port for a remote Plex server
 const remotePlex = "http://*IP*:*Port number*";
 
-//the url and port for a local json server which will host your reviews, users, and favorites
-export const dbURL = "http://localhost:8088";
+//Where the users/reviews/favorites data API lives.
+//  - In local development this is the json-server you run from the `api/` folder.
+//  - In production (the Azure Static Web App build) it is the bundled Azure Functions
+//    API, served at the same origin under "/api".
+//Change the dev URL here if you run json-server on a different port.
+export const dbURL =
+  process.env.NODE_ENV === "production" ? "/api" : "http://localhost:8088";
 
 //for url, choose either 'remotePlex' or 'localPlex' depending on the location of the server you want to access
 export const url = remotePlex;

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { dbURL } from "../Settings";
 import "./Login.css";
 
 export const Login = ({ setAuthUser }) => {
@@ -15,7 +16,7 @@ export const Login = ({ setAuthUser }) => {
   };
 
   const existingUserCheck = () => {
-    return fetch(`http://localhost:8088/users?email=${loginUser.email}`)
+    return fetch(`${dbURL}/users?email=${loginUser.email}`)
       .then((res) => res.json())
       .then((user) => (user.length ? user[0] : false));
   };

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { dbURL } from "../Settings";
 import "./Login.css";
 
 export const Register = ({ setAuthUser }) => {
@@ -19,7 +20,7 @@ export const Register = ({ setAuthUser }) => {
   };
 
   const existingUserCheck = () => {
-    return fetch(`http://localhost:8088/users?email=${registerUser.email}`)
+    return fetch(`${dbURL}/users?email=${registerUser.email}`)
       .then((res) => res.json())
       .then((user) => !!user.length);
   };
@@ -29,7 +30,7 @@ export const Register = ({ setAuthUser }) => {
 
     existingUserCheck().then((userExists) => {
       if (!userExists) {
-        fetch("http://localhost:8088/users", {
+        fetch(`${dbURL}/users`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## What & why

Makes Remote-Watch hostable as an **Azure Static Web App**. The blocker was the two
dev-only backends behind the React UI; this PR replaces the data backend and wires up
SWA deployment. The front end already had an SWA workflow.

## Changes

- **New Azure Functions API (`api/`)** — replaces the dev-only `json-server`. v4
  programming model, backed by **Azure Table Storage** (`@azure/data-tables`). The
  `users` / `favorites` / `reviews` endpoints replicate the json-server contract the
  client expects, including `reviews?_expand=user` (the join `ReviewCard` needs via
  `review.user.name`). IDs are kept **numeric** so the UI's strict-equality checks
  (`thisFav.userId === currentUser`) keep working. Includes a `seed.js` for the admin user.
- **Client wiring** — removed the three hardcoded `localhost:8088` URLs in
  `Login.js` / `Register.js`; `Settings-template.js` now switches `dbURL` to `/api`
  in production builds automatically.
- **SWA plumbing** — `api_location: api` in the workflow; `staticwebapp.config.json`
  for SPA fallback routing; `.env` with `CI=false` so CRA's "warnings-as-errors in CI"
  doesn't fail the first cloud build on pre-existing lint warnings.
- **Docs** — README gains a step-by-step "Deploying to Azure" guide.

## Verified

- `api/` modules load and register under the Functions v4 runtime.
- `npm run build` (CRA production build) compiles successfully.

## Follow-ups required before the deployed app is fully functional (infra, not code)

- **Plex Remote Access + HTTPS** — the browser streams directly from Plex, so it must be
  internet-reachable over its `*.plex.direct` HTTPS address (plain `http` is blocked as
  mixed content) with CORS allowing the SWA origin.
- **Azure resources** — create a Storage account, set `TABLES_CONNECTION_STRING` in the
  SWA app settings, and run `api/seed.js`.
- Note: the X-Plex-Token is bundled into the public client JS, so only deploy a
  token/collection you're comfortable exposing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
